### PR TITLE
Fix Segmentation Fault

### DIFF
--- a/ext/exif/data.c
+++ b/ext/exif/data.c
@@ -265,6 +265,12 @@ static void each_entry(ExifEntry *entry, void *self_ptr) {
 
   ivar_name = exif_entry_to_ivar(entry);
   value = exif_entry_to_rb_value(entry);
+
+  if (ivar_name == 0x00) {
+    rb_warning("Unsupported tag %x", entry->tag);
+    return;
+  }
+
   rb_hash_aset(rb_hash_aref(rb_iv_get(*(VALUE *)self_ptr, "@ifds"),
                             ID2SYM(rb_intern(
                                 ifd_name_mapping[exif_entry_get_ifd(entry)]))),


### PR DESCRIPTION
I tryed to use exif with Docker official ruby image ruby:2.7.1-alpine.
This image based on alpine linux 3.12.0, the libexif-dev is updated to 0.6.22.
If the tag of exif is unsupported, Segmentation fault is occered. 

So, I added the warning if the tag is unsupported.

How do you think this?

## Try to test the docker image

### Before add the warning

- https://travis-ci.org/github/kysnm/exif/builds/717485205

### After add the warning

- https://travis-ci.org/github/kysnm/exif/builds/717492266