### PR TITLE
build: try to use `pkg-config` to get `libexif` directories

### DIFF
--- a/ext/exif/extconf.rb
+++ b/ext/exif/extconf.rb
@@ -2,6 +2,7 @@
 
 require 'mkmf'
 $CFLAGS << ' -std=c99 '
+pkg_config('libexif')
 have_library('exif')
 have_header('libexif/exif-data.h')
 create_makefile('exif/exif')


### PR DESCRIPTION
If found using `pkg-config`, the `CFLAGS`, `LDFLAGS` and `INCFLAGS` will be set to the correct values, according to https://ruby-doc.org/stdlib-3.1.0/libdoc/mkmf/rdoc/MakeMakefile.html#method-i-pkg_config

This should solve the issues when `libexif` is installed in a non-standard path, for example with Homebrew. It maybe fixes #4 as well (if `pkg-config` is properly setup on Windows).

This has been tested on my M1 Mac with Homebrew (installed in the new `/opt/homebrew/` prefix) and it fixed the issues I had.