### PR TITLE
Fix compilation with libexif < 0.6.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - master
           - libexif-0_6_21-release
           - libexif-0_6_22-release
-          - libexif-0_6_23-release
+          # No 0.6.23 as this release broke JPEG EXIF handling, and our tests rely on it
           - libexif-0_6_24-release
 
     steps:

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -24,5 +24,6 @@ void Init_exif(void) {
       rb_define_class_under(rb_mExif, "UnknownDataType", rb_eError);
   rb_define_singleton_method(rb_mExif, "const_missing", rb_exif_const_missing,
                              1);
+  rb_define_const(rb_mExif, "LIBEXIF_VERSION", rb_str_new2(LIBEXIF_VERSION));
   init_data();
 }

--- a/ext/exif/exif_entry_to_ivar.c
+++ b/ext/exif/exif_entry_to_ivar.c
@@ -447,6 +447,7 @@ const char *exif_entry_to_ivar(ExifEntry *ee) {
   case EXIF_TAG_GPS_DIFFERENTIAL:
     return "@gps_differential";
     break;
+  #ifdef LIBEXIF_0_6_22_OR_HIGHER
   case EXIF_TAG_BODY_SERIAL_NUMBER:
     return "@body_serial_number";
     break;
@@ -459,18 +460,6 @@ const char *exif_entry_to_ivar(ExifEntry *ee) {
   case EXIF_TAG_GPS_H_POSITIONING_ERROR:
     return "@gps_h_positioning_error";
     break;
-  case EXIF_TAG_IMAGE_DEPTH:
-    return "@image_depth";
-    break;
-  case EXIF_TAG_ISO_SPEED:
-    return "@iso_speed";
-    break;
-  case EXIF_TAG_ISO_SPEEDLatitudeYYY:
-    return "@iso_speedlatitudeyyy";
-    break;
-  case EXIF_TAG_ISO_SPEEDLatitudeZZZ:
-    return "@iso_speedlatitudezzz";
-    break;
   case EXIF_TAG_LENS_MAKE:
     return "@lens_make";
     break;
@@ -482,6 +471,26 @@ const char *exif_entry_to_ivar(ExifEntry *ee) {
     break;
   case EXIF_TAG_LENS_SPECIFICATION:
     return "@lens_specification";
+    break;
+  case EXIF_TAG_SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE:
+    return "@source_exposure_times_of_composite_image";
+    break;
+  case EXIF_TAG_SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE:
+    return "@source_image_number_of_composite_image";
+    break;
+  #endif
+  #ifdef LIBEXIF_0_6_23_OR_HIGHER
+  case EXIF_TAG_IMAGE_DEPTH:
+    return "@image_depth";
+    break;
+  case EXIF_TAG_ISO_SPEED:
+    return "@iso_speed";
+    break;
+  case EXIF_TAG_ISO_SPEEDLatitudeYYY:
+    return "@iso_speedlatitudeyyy";
+    break;
+  case EXIF_TAG_ISO_SPEEDLatitudeZZZ:
+    return "@iso_speedlatitudezzz";
     break;
   case EXIF_TAG_OFFSET_TIME:
     return "@offset_time";
@@ -498,15 +507,10 @@ const char *exif_entry_to_ivar(ExifEntry *ee) {
   case EXIF_TAG_SENSITIVITY_TYPE:
     return "@sensitivity_type";
     break;
-  case EXIF_TAG_SOURCE_EXPOSURE_TIMES_OF_COMPOSITE_IMAGE:
-    return "@source_exposure_times_of_composite_image";
-    break;
-  case EXIF_TAG_SOURCE_IMAGE_NUMBER_OF_COMPOSITE_IMAGE:
-    return "@source_image_number_of_composite_image";
-    break;
   case EXIF_TAG_STANDARD_OUTPUT_SENSITIVITY:
     return "@standard_output_sensitivity";
     break;
+  #endif
   }
   return 0;
 }

--- a/ext/exif/extconf.rb
+++ b/ext/exif/extconf.rb
@@ -18,4 +18,7 @@ checking_for 'libexif >= 0.6.23' do
   end
 end
 
+libexif_version = pkg_config('libexif', 'modversion') || 'unknown'
+append_cflags("-D LIBEXIF_VERSION='\"#{libexif_version}\"'")
+
 create_makefile('exif/exif')

--- a/ext/exif/extconf.rb
+++ b/ext/exif/extconf.rb
@@ -5,4 +5,17 @@ $CFLAGS << ' -std=c99 '
 pkg_config('libexif')
 have_library('exif')
 have_header('libexif/exif-data.h')
+
+checking_for 'libexif >= 0.6.22' do
+  if try_const(%w[EXIF_TAG_LENS_SPECIFICATION ExifTag], 'libexif/exif-tag.h')
+    append_cflags('-D LIBEXIF_0_6_22_OR_HIGHER')
+  end
+end
+
+checking_for 'libexif >= 0.6.23' do
+  if try_const(%w[EXIF_TAG_IMAGE_DEPTH ExifTag], 'libexif/exif-tag.h')
+    append_cflags('-D LIBEXIF_0_6_23_OR_HIGHER')
+  end
+end
+
 create_makefile('exif/exif')

--- a/test/test_exif.rb
+++ b/test/test_exif.rb
@@ -41,7 +41,7 @@ class TestExif < Minitest::Test
         resolution_unit: 2
       }, data.ifds[:ifd1])
 
-      assert_equal({
+      expected_exif = {
         exposure_time: Rational(1, 125),
         fnumber: Rational(8, 1),
         exposure_program: 3,
@@ -81,16 +81,29 @@ class TestExif < Minitest::Test
         sharpness: 0,
         subject_distance_range: 0,
         flash_pix_version: '0100',
-        sensitivity_type: 2,
-        body_serial_number: '8011371',
-        lens_specification: [
-          Rational(24, 1),
-          Rational(70, 1),
-          Rational(14, 5),
-          Rational(14, 5)
-        ],
-        lens_model: '24.0-70.0 mm f/2.8'
-      }, data.ifds[:exif])
+      }
+
+      if Gem::Version.new(Exif::LIBEXIF_VERSION) >= Gem::Version.new('0.6.22')
+        expected_exif.merge!(
+          body_serial_number: '8011371',
+          lens_specification: [
+            Rational(24, 1),
+            Rational(70, 1),
+            Rational(14, 5),
+            Rational(14, 5)
+          ],
+          lens_model: '24.0-70.0 mm f/2.8',
+        )
+      end
+
+      if Gem::Version.new(Exif::LIBEXIF_VERSION) >= Gem::Version.new('0.6.23')
+        expected_exif.merge!(
+          sensitivity_type: 2,
+        )
+      end
+
+
+      assert_equal(expected_exif, data.ifds[:exif])
 
       assert_equal({
         gps_version_id: [2, 2, 0, 0],


### PR DESCRIPTION
It uses an `mkmf` macro to check if we are building against `libexif` >= 0.6.23 or not, according to the `ExifTag` enum values.

Fixes #34