### PR TITLE
Run tests with Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: rake test
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.1', '3.0', '2.7']
+        libexif-version: ['system', 'latest']
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install libexif from system
+        run: sudo apt-get install libexif-dev
+        if: ${{ matrix.libexif-version == 'system' }}
+      - name: Uninstall libexif from system
+        run: sudo apt-get remove libexif12 libexif-dev
+        if: ${{ matrix.libexif-version == 'latest' }}
+      - uses: robinraju/release-downloader@v1.3
+        name: Download latest libexif
+        if: ${{ matrix.libexif-version == 'latest' }}
+        with:
+          repository: "libexif/libexif"
+          latest: true
+          zipBall: false
+          tarBall: true
+      - name: Install latest libexif
+        if: ${{ matrix.libexif-version == 'latest' }}
+        run: |
+          sudo apt-get install autopoint
+          mkdir libexif
+          tar xvf libexif-libexif*.tar.gz -C libexif --strip-components 1
+          cd libexif
+          autoreconf -i
+          ./configure --prefix=/usr
+          make
+          sudo make install
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,40 +15,43 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ['3.1', '3.0', '2.7']
-        libexif-version: ['system', 'latest']
+        libexif-version:
+          - system
+          - master
+          - libexif-0_6_21-release
+          - libexif-0_6_22-release
+          - libexif-0_6_23-release
+          - libexif-0_6_24-release
 
     steps:
       - uses: actions/checkout@v2
       - name: Install libexif from system
         run: sudo apt-get install libexif-dev
         if: ${{ matrix.libexif-version == 'system' }}
-      - name: Uninstall libexif from system
-        run: sudo apt-get remove libexif12 libexif-dev
-        if: ${{ matrix.libexif-version == 'latest' }}
-      - uses: robinraju/release-downloader@v1.3
-        name: Download latest libexif
-        if: ${{ matrix.libexif-version == 'latest' }}
+      - name: Checkout libexif
+        uses: actions/checkout@v2
         with:
-          repository: "libexif/libexif"
-          latest: true
-          zipBall: false
-          tarBall: true
-      - name: Install latest libexif
-        if: ${{ matrix.libexif-version == 'latest' }}
+          repository: libexif/libexif
+          ref: ${{matrix.libexif-version}}
+          path: libexif
+        if: ${{ matrix.libexif-version != 'system' }}
+      - name: Set up libexif
         run: |
-          sudo apt-get install autopoint
-          mkdir libexif
-          tar xvf libexif-libexif*.tar.gz -C libexif --strip-components 1
+          sudo apt-get update
+          sudo apt-get remove libexif12 libexif-dev
+          sudo apt-get install autopoint gettext
           cd libexif
           autoreconf -i
-          ./configure --prefix=/usr
-          make
+          ./configure --disable-docs --prefix=/usr
+          make -j $(nproc)
           sudo make install
+        if: ${{ matrix.libexif-version != 'system' }}
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
       - name: Install dependencies
-        run: bundle install
+        run: bundle install --jobs $(nproc)
       - name: Run tests
         run: bundle exec rake


### PR DESCRIPTION
For each PR and commit to the `master` branch, tests will be run on:
- Ruby 2.7, 3.0 and 3.1
- Ubuntu's `libexif`, as well as the latest version downloaded from Github and built before building the gem

Here is an example run: https://github.com/renchap/exif/actions/runs/1971438288
You can see that building the gem fails with using `libexif` from system, but works with the latest version.